### PR TITLE
Check if track has an artists array before extracting the artist name

### DIFF
--- a/ytm_ll_dl/main.py
+++ b/ytm_ll_dl/main.py
@@ -75,8 +75,10 @@ def main(
                 print(prefix + str(x))
 
             id = track['videoId']
+            artist = "Unknown Artist"
 
-            artist = track['artists'][0]['name']
+            if track['artists'] and len(track['artists']) > 0:
+                artist = track['artists'][0]['name']
             title = track['title']
             album = track['album']['name'] if track['album'] else None
 


### PR DESCRIPTION
Looks like the `artists` key on uploaded tracks (or some of them) is `None`, which makes the script fail with this error:

```
Traceback (most recent call last):
  File "/home/ovidiu/.local/bin/ytm-ll-dl", line 8, in <module>
    sys.exit(main())
  File "/home/ovidiu/.local/lib/python3.10/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/home/ovidiu/.local/lib/python3.10/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/home/ovidiu/.local/lib/python3.10/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/ovidiu/.local/lib/python3.10/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/home/ovidiu/.local/lib/python3.10/site-packages/ytm_ll_dl/main.py", line 80, in main
    artist = track['artists'][0]['name']
TypeError: 'NoneType' object is not subscriptable
```

This is a print of the track object that caused the error:

`{'videoId': 'PjQRBxl4AU0', 'title': 'Disclosure - Help Me Lose My Mind (Mazde Remix)[www.vitanclub.net]', 'artists': None, 'album': None, 'likeStatus': 'LIKE', 'thumbnails': [{'url': 'https://www.gstatic.com/youtube/media/ytm/images/cover_track_default@1200.png?sqp=CPXnx-oF-oaymwEGCDwQPFgB&rs=ALLJMcKG4HoG-nDcHAjjtvKnA1-TsHbplA', 'width': 60, 'height': 60}, {'url': 'https://www.gstatic.com/youtube/media/ytm/images/cover_track_default@1200.png?sqp=CMnnx-oF-oaymwEGCHgQeFgB&rs=ALLJMcJMYVX-njU3_fFWsT7BvREyrfEBFQ', 'width': 120, 'height': 120}], 'isAvailable': True, 'isExplicit': False, 'duration': '3:56', 'duration_seconds': 236}
`

This pull request checks if `track['artists']` is `None` and, if it does, it sets the value for artist to Unknown Artist.